### PR TITLE
Design/#11

### DIFF
--- a/Kiosk/Button/ButtonAction.swift
+++ b/Kiosk/Button/ButtonAction.swift
@@ -1,0 +1,19 @@
+//
+//  ButtonAction.swift
+//  Kiosk
+//
+//  Created by 최규현 on 4/9/25.
+//
+
+import UIKit
+
+extension ViewController {
+    
+    @objc func orderButtonTapped() {
+        
+    }
+    
+    @objc func cancelButtonTapped() {
+        
+    }
+}

--- a/Kiosk/Button/UIButtonExtension.swift
+++ b/Kiosk/Button/UIButtonExtension.swift
@@ -1,0 +1,29 @@
+//
+//  UIButtonExtension.swift
+//  Kiosk
+//
+//  Created by 최규현 on 4/9/25.
+//
+
+import UIKit
+
+/*
+ button.backgroundColor 로 백그라운드 컬러 생성 시
+ 버튼의 클릭 이펙트가 출력되지 않는 현상 개션을 위해
+ 버튼의 상태별 백그라운드 컬러를 지정할 수 있는 메서드를 생성
+ */
+extension UIButton {
+    func setBackgroundColor(_ color: UIColor, for state: UIControl.State) {
+        
+        UIGraphicsBeginImageContext(CGSize(width: 1.0, height: 1.0))
+        guard let context = UIGraphicsGetCurrentContext() else { return }
+        
+        context.setFillColor(color.cgColor)
+        context.fill(CGRect(x: 0.0, y: 0.0, width: 1.0, height: 1.0))
+        
+        let backgroundImage = UIGraphicsGetImageFromCurrentImageContext()
+        UIGraphicsEndImageContext()
+        
+        setBackgroundImage(backgroundImage, for: state)
+    }
+}

--- a/Kiosk/CollectionView/CollectionViewCell.swift
+++ b/Kiosk/CollectionView/CollectionViewCell.swift
@@ -36,6 +36,8 @@ class CollectionViewCell: UICollectionViewCell {
     var infoLabel = UILabel()
     var imageView = UIImageView()
     
+    var separatedView = UIView()
+    
     // UI세팅 메서드
     func configure() {
         
@@ -62,10 +64,10 @@ class CollectionViewCell: UICollectionViewCell {
         
         imageView.contentMode = .scaleAspectFit
         
-        contentView.layer.borderWidth = 0.3
-        contentView.layer.borderColor = UIColor.lightGray.cgColor
+        separatedView.backgroundColor = .lightGray
         
-        [nameLabel, priceLabel, saleLabel, originalPriceLabel,infoNameLabel, infoLabel, imageView]
+        [nameLabel, priceLabel, saleLabel, originalPriceLabel,
+         infoNameLabel, infoLabel, imageView, separatedView]
             .forEach {
                 $0.translatesAutoresizingMaskIntoConstraints = false
                 contentView.addSubview($0)
@@ -93,7 +95,12 @@ class CollectionViewCell: UICollectionViewCell {
             saleLabel.bottomAnchor.constraint(equalTo: priceLabel.bottomAnchor),
             
             originalPriceLabel.trailingAnchor.constraint(equalTo: priceLabel.trailingAnchor),
-            originalPriceLabel.bottomAnchor.constraint(equalTo: priceLabel.topAnchor, constant: -4)
+            originalPriceLabel.bottomAnchor.constraint(equalTo: priceLabel.topAnchor, constant: -4),
+            
+            separatedView.widthAnchor.constraint(equalTo: contentView.widthAnchor),
+            separatedView.heightAnchor.constraint(equalToConstant: 0.5),
+            separatedView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
+            separatedView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor)
             ])
     }
     

--- a/Kiosk/CollectionView/CollectionViewDelegate.swift
+++ b/Kiosk/CollectionView/CollectionViewDelegate.swift
@@ -46,16 +46,27 @@ extension ViewController: UICollectionViewDataSource {
         } else {
             guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: CollectionViewCell.id, for: indexPath) as? CollectionViewCell else { return UICollectionViewCell() }
             
+            cell.configure()
+            
             switch SegmentState(rawValue: state) {
             case .jeontongjoo:
-                cell.configure()
                 cell.setJeontongjoo(jeontongjooList[indexPath.item])
+                
+                let isLastCell = indexPath.item == jeontongjooList.count - 1
+                cell.separatedView.isHidden = isLastCell
+                
             case .wine:
-                cell.configure()
                 cell.setWine(wineList[indexPath.item])
+                
+                let isLastCell = indexPath.item == wineList.count - 1
+                cell.separatedView.isHidden = isLastCell
+                
             case .sake:
-                cell.configure()
                 cell.setSake(sakeList[indexPath.item])
+                
+                let isLastCell = indexPath.item == sakeList.count - 1
+                cell.separatedView.isHidden = isLastCell
+                
             default:
                 print("Error")
             }

--- a/Kiosk/CollectionView/ViewControllerExtension.swift
+++ b/Kiosk/CollectionView/ViewControllerExtension.swift
@@ -21,19 +21,49 @@ extension ViewController {
         let collectionView = CollectionView(frame: .zero, collectionViewLayout: collectionViewLayer)
         collectionView.backgroundColor = .white
         collectionView.layer.cornerRadius = 20
-        collectionView.translatesAutoresizingMaskIntoConstraints = false
         
-        view.addSubview(collectionView)
+        self.collectionView = collectionView
+        
+        cancelButton.setTitle("주문 취소", for: .normal)
+        cancelButton.setBackgroundColor(.sub2, for: .normal)
+        cancelButton.addTarget(self, action: #selector(cancelButtonTapped), for: .touchUpInside)
+        
+        orderButton.setTitle("주문 하기", for: .normal)
+        orderButton.setBackgroundColor(.sub1, for: .normal)
+        orderButton.addTarget(self, action: #selector(orderButtonTapped), for: .touchUpInside)
+        
+        [orderButton, cancelButton]
+            .forEach {
+                $0.titleLabel?.font = .boldSystemFont(ofSize: 20)
+                $0.setTitleColor(.main, for: .normal)
+                $0.layer.cornerRadius = 21.5
+                $0.layer.masksToBounds = true
+            }
+        
+        [collectionView, orderButton, cancelButton]
+            .forEach {
+                $0.translatesAutoresizingMaskIntoConstraints = false
+                view.addSubview($0)
+            }
         
         // 오토레이아웃 설정
         NSLayoutConstraint.activate([
             collectionView.topAnchor.constraint(equalTo: view.topAnchor, constant: 160),
             collectionView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 12),
             collectionView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -12),
-            collectionView.heightAnchor.constraint(equalToConstant: 310)
+            collectionView.heightAnchor.constraint(equalToConstant: 310),
+            
+            cancelButton.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: -40),
+            cancelButton.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 12),
+            cancelButton.widthAnchor.constraint(equalToConstant: 168),
+            cancelButton.heightAnchor.constraint(equalToConstant: 43),
+            
+            orderButton.bottomAnchor.constraint(equalTo: cancelButton.bottomAnchor),
+            orderButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -12),
+            orderButton.widthAnchor.constraint(equalToConstant: 168),
+            orderButton.heightAnchor.constraint(equalToConstant: 43)
         ])
         
-        self.collectionView = collectionView
     }
     
     // identifier 설정(CollectionViewCell에서 만들었던 id 사용)

--- a/Kiosk/CollectionView/ViewControllerExtension.swift
+++ b/Kiosk/CollectionView/ViewControllerExtension.swift
@@ -35,7 +35,7 @@ extension ViewController {
         [orderButton, cancelButton]
             .forEach {
                 $0.titleLabel?.font = .boldSystemFont(ofSize: 20)
-                $0.setTitleColor(.main, for: .normal)
+                $0.setTitleColor(.white, for: .normal)
                 $0.layer.cornerRadius = 21.5
                 $0.layer.masksToBounds = true
             }

--- a/Kiosk/ViewController.swift
+++ b/Kiosk/ViewController.swift
@@ -60,6 +60,11 @@ class ViewController: UIViewController {
     
     // Segmented Controll을 누르면 바뀌며 collectionView를 전환하기 위한 변수
     var state = "sake"
+    
+    // MARK: - >>>>>>>>>>>>>>>>> 최규현 버튼 생성 <<<<<<<<<<<<<<<<<<<<<<<<<
+    let orderButton = UIButton()
+    let cancelButton = UIButton()
+    
 }
 
 


### PR DESCRIPTION
close #1 
close #No(이슈 넘버 등록하면 자동으로 이슈가 닫힙니다. 이슈를 닫고 싶지 않다면, 즉 해당 이슈의 작업이 아직 끝나지 않았다면 닫지 않습니다.)

## *⛳️ Work Description*
- 주문하기, 주문 취소 버튼 UI 구현
- 하는 김에 menu CollectionViewCell의 구분선 생성 방식도 변경했습니다.
 
## *📸 Screenshot*
![Simulator Screenshot - iPhone 13 mini - 2025-04-09 at 17 33 58](https://github.com/user-attachments/assets/96ee1481-0d3a-419c-ab07-6c55090fdeae)


## *📢 To Reviewers*
- 코드리뷰 부탁드립니다. 

## *✅ Checklist*
- [x] `UIButton`을 사용하여 `주문 취소` 버튼 구현
- [x] `UIButton`을 사용하여 `주문 하기` 버튼 구현
- [x] 제약 설정 완료하기
