### PR TITLE
[Feat] #12 - 취소 버튼 기능 구현

### DIFF
--- a/Kiosk/Button/ButtonAction.swift
+++ b/Kiosk/Button/ButtonAction.swift
@@ -14,6 +14,18 @@ extension ViewController {
     }
     
     @objc func cancelButtonTapped() {
+        let cancelAlert = UIAlertController(title: "주문 취소", message: "주문을 취소하시겠습니까?", preferredStyle: .alert)
         
+        let yesAction = UIAlertAction(title: "네", style: .default) { _ in
+            self.cartItems = []
+            self.cartCollectionView.reloadData()
+        }
+        
+        let cancelAction = UIAlertAction(title: "아니요", style: .cancel, handler: nil)
+        
+        cancelAlert.addAction(yesAction)
+        cancelAlert.addAction(cancelAction)
+        
+        present(cancelAlert, animated: true)
     }
 }


### PR DESCRIPTION
close #12 

## *⛳️ Work Description*
- 주문 취소 버튼 액션 구현
 
## *📸 Screenshot*
![Simulator Screen Recording - iPhone 13 mini - 2025-04-09 at 19 23 59](https://github.com/user-attachments/assets/a89317f2-be00-4c46-a36c-1e0745315528)


## *📢 To Reviewers*
- 코드리뷰 부탁드립니다. 

## *✅ Checklist*
 - [x] 버튼을 탭하면 Alert 창을 띄우게 구현
 - [x]  `네` `아니오` 를 선택할 수 있게 구현
 - [x] `네` 선택 시, 장바구니를 비워지게 구현
 - [x] `아니오` 선택 시, Alert 창만 닫히게 구현

