### PR TITLE
[Feat] #13 - 주문하기 버튼 액션 구현

### DIFF
--- a/Kiosk/Button/ButtonAction.swift
+++ b/Kiosk/Button/ButtonAction.swift
@@ -9,10 +9,32 @@ import UIKit
 
 extension ViewController {
     
+    // MARK: - Order Button Action
     @objc func orderButtonTapped() {
+        let orderAlert = UIAlertController(title: "주문하기", message: "주문하시겠습니까?", preferredStyle: .alert)
+        let successAlert = UIAlertController(title: "주문 완료!", message: "주문이 완료되었습니다.", preferredStyle: .alert)
         
+        let yesAction = UIAlertAction(title: "네", style: .default) { _ in
+//            self.cartItems.forEach { orderHistory.append($0) }
+            
+            self.cartItems = []
+            self.cartCollectionView.reloadData()
+            self.present(successAlert, animated: true)
+            
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1.2) {
+                successAlert.dismiss(animated: true)
+            }
+        }
+        
+        let cancelAction = UIAlertAction(title: "아니요", style: .cancel, handler: nil)
+        
+        orderAlert.addAction(yesAction)
+        orderAlert.addAction(cancelAction)
+        
+        present(orderAlert, animated: true)
     }
     
+    // MARK: - Cancel Button Action
     @objc func cancelButtonTapped() {
         
     }


### PR DESCRIPTION
close #13 

## *⛳️ Work Description*
- 주문하기 버튼 액션 구현
 
## *📸 Screenshot*
![Simulator Screen Recording - iPhone 13 mini - 2025-04-09 at 20 09 35](https://github.com/user-attachments/assets/d25b9483-e583-47f3-905c-bb4272520a3c)


## *📢 To Reviewers*
- 코드리뷰 부탁드립니다. 

## *✅ Checklist*
- [x] 버튼을 탭하면 Alert 창을 띄우게 구현
- [x]  `네` `아니오` 를 선택할 수 있게 구현
- [x] `네` 선택 시, `결제가 완료` 라는 알림창을 띄우는 기능 구현
- [x] `아니오` 선택 시, Alert 창만 닫히게 구현