### PR TITLE
Fix/#26

### DIFF
--- a/Kiosk/Cart/CartCollectionViewCell.swift
+++ b/Kiosk/Cart/CartCollectionViewCell.swift
@@ -119,8 +119,6 @@ extension CartCollectionViewCell {
         NSLayoutConstraint.activate([
             itemNameLabel.widthAnchor.constraint(equalToConstant: 168),
             itemNameLabel.heightAnchor.constraint(equalToConstant: 18),
-            itemNameLabel.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 8),
-            itemNameLabel.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -8),
             itemNameLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 18),
         ])
     }
@@ -146,8 +144,6 @@ extension CartCollectionViewCell {
         NSLayoutConstraint.activate([
             itemCountLabel.widthAnchor.constraint(equalToConstant: 25),
             itemCountLabel.heightAnchor.constraint(equalToConstant: 18),
-            itemCountLabel.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 8),
-            itemCountLabel.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -8),
             itemCountLabel.leadingAnchor.constraint(equalTo: minusButton.trailingAnchor, constant: 4)
         ])
     }
@@ -172,10 +168,7 @@ extension CartCollectionViewCell {
         NSLayoutConstraint.activate([
             itemPriceLabel.widthAnchor.constraint(equalToConstant: 72),
             itemPriceLabel.heightAnchor.constraint(equalToConstant: 18),
-            itemPriceLabel.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 8),
-            itemPriceLabel.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -8),
             itemPriceLabel.leadingAnchor.constraint(equalTo: plusButton.trailingAnchor, constant: 10)
-            //itemPriceLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor)
         ])
     }
     

--- a/Kiosk/Cart/CartCollectionViewCell.swift
+++ b/Kiosk/Cart/CartCollectionViewCell.swift
@@ -119,6 +119,7 @@ extension CartCollectionViewCell {
         NSLayoutConstraint.activate([
             itemNameLabel.widthAnchor.constraint(equalToConstant: 168),
             itemNameLabel.heightAnchor.constraint(equalToConstant: 18),
+            itemNameLabel.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
             itemNameLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 18),
         ])
     }
@@ -144,6 +145,7 @@ extension CartCollectionViewCell {
         NSLayoutConstraint.activate([
             itemCountLabel.widthAnchor.constraint(equalToConstant: 25),
             itemCountLabel.heightAnchor.constraint(equalToConstant: 18),
+            itemCountLabel.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
             itemCountLabel.leadingAnchor.constraint(equalTo: minusButton.trailingAnchor, constant: 4)
         ])
     }
@@ -168,6 +170,7 @@ extension CartCollectionViewCell {
         NSLayoutConstraint.activate([
             itemPriceLabel.widthAnchor.constraint(equalToConstant: 72),
             itemPriceLabel.heightAnchor.constraint(equalToConstant: 18),
+            itemPriceLabel.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
             itemPriceLabel.leadingAnchor.constraint(equalTo: plusButton.trailingAnchor, constant: 10)
         ])
     }


### PR DESCRIPTION
close #26 
close #No(이슈 넘버 등록하면 자동으로 이슈가 닫힙니다. 이슈를 닫고 싶지 않다면, 즉 해당 이슈의 작업이 아직 끝나지 않았다면 닫지 않습니다.)

## *⛳️ Work Description*
- 경고를 발생하는 제약 조건 찾기
- 제약 조건을 경고가 발생하지 않게 변경하기

## *📸 Screenshot*
### 변경 전: 장바구니에 상품 담으면 경고 발생
![image](https://github.com/user-attachments/assets/9a277380-a009-44f4-80e9-da6cbee6ea5a)

### 변경 후: 경고 발생 안함
https://github.com/user-attachments/assets/061a050f-f76d-4485-9712-894a092913fc


## *📢 To Reviewers*
- 장바구니의 상품이름 수량 가격 라벨의 top, bottom 제약조건에 실수가 있었습니다.
- top과 bottom 제약을 지우고 centerY 를 contentView 에 제약을 걸어서 해결했습니다.

## *✅ Checklist*
- [x] 주석 및 프린트문 제거 확인.
- [x] 컨벤션 준수 확인.
- PR을 올리기 전에 PR을 올리는 대상자가 점검할 내용입니다.
