### PR TITLE
[Fix] #32 - Menu CollectionView 위치 조정

### DIFF
--- a/Kiosk/CollectionView/ViewControllerExtension.swift
+++ b/Kiosk/CollectionView/ViewControllerExtension.swift
@@ -48,7 +48,7 @@ extension ViewController {
         
         // 오토레이아웃 설정
         NSLayoutConstraint.activate([
-            collectionView.topAnchor.constraint(equalTo: view.topAnchor, constant: 160),
+            collectionView.topAnchor.constraint(equalTo: view.topAnchor, constant: 169),
             collectionView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 12),
             collectionView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -12),
             collectionView.heightAnchor.constraint(equalToConstant: 310),


### PR DESCRIPTION
close #32 

## *⛳️ Work Description*
- Fix Menu CollectionView's AutoLayout
- customSegmentedControl.bottomAnchor에 걸면 왜인지 오류가 발생해서 view.topAnchor에 걸었습니다.
 
## *📸 Screenshot*
![Simulator Screenshot - iPhone 13 mini - 2025-04-10 at 17 36 55](https://github.com/user-attachments/assets/bc0e62fa-ac5c-4966-b40d-caef57016a0d)


## *📢 To Reviewers*
- 코드리뷰 부탁드립니다. 

## *✅ Checklist*
- [x] 수정 사항 확인
