### PR TITLE
[Fix] #37 - 총금액 표시하는 라벨에서 `원` 이 사라지는 현상 수정

### DIFF
--- a/Kiosk/TotalAmount/TotalAmountView.swift
+++ b/Kiosk/TotalAmount/TotalAmountView.swift
@@ -21,7 +21,7 @@ extension ViewController {
     
     // 총 금액 업데이트 메소드
     func updateTotalPrice(to newPrice: Int) {
-        totalAmountLabel.text = "\(convertToCurrencyFormat(price: newPrice))"
+        totalAmountLabel.text = "\(convertToCurrencyFormat(price: newPrice)) 원"
     }
 
     // 총 수량 업데이트 메소드


### PR DESCRIPTION
close #37 

## *⛳️ Work Description*
- 총금액을 새로고침하는 메소드에서 "원" 이 누락되어 발생하였습니다.
- 해당 메소드를 수정하였습니다.
 
## *📸 Screenshot*
### 변경 전
![Simulator Screen Recording - iPhone 13 mini - 2025-04-10 at 18 11 41](https://github.com/user-attachments/assets/4e64b4df-fd58-4e09-a6ec-7f61f125c137)

### 변경 후
![Simulator Screen Recording - iPhone 13 mini - 2025-04-10 at 18 14 06](https://github.com/user-attachments/assets/9abc3a4d-5a03-40ad-89d0-650927f4c7da)

## *📢 To Reviewers*
- 코드리뷰 부탁드립니다. 
- 월요일 고생하셨습니다.
- 이 PR을 리뷰하는 사람들에게 할 말이 있다면 작성하시면 됩니다. 

## *✅ Checklist*
- [x] 주석 및 프린트문 제거 확인.
- [x] 컨벤션 준수 확인.
- PR을 올리기 전에 PR을 올리는 대상자가 점검할 내용입니다.
